### PR TITLE
Feature/parse json context to cel

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,6 @@ Learning Rust by playing with the [Common Expression Language](https://github.co
 - Benchmark the Cloud Custodian Python-CEL implementation against the Rust ones.
 - Use an existing Lexer like [Logos](https://docs.rs/logos/latest/logos/)
 
-## Existing Implementations
-
-- [clarkmcc/cel-rust](https://github.com/clarkmcc/cel-rust) (Maintained fork of [orf/cel-rust](https://github.com/orf/cel-rust).)
-  Implements separate crates for parser (using lalrpop) and interpreter (straightforward treewalk interpreter).
-- [thesayyn/cel-rust](https://github.com/thesayyn/cel-rust) (Incomplete). WASM target with online [demo](https://thesayyn.github.io/cel-rust/).
-  Parser uses lalrpop.
-
-Test Data
-
-https://github.com/google/cel-spec/blob/master/tests/simple/testdata/basic.textproto
 
 ## Execution
 
@@ -44,26 +34,48 @@ NumericCelType(Float(-15.0))
 ```
 
 Note the parser is not complete, so it will fail on some valid expressions. At this stage I'm not
-intending to implement a full interpreter with all built in functions, just enough to get a feel for
-the language and the parser.
+intending to implement a full interpreter with all built-in functions, just enough to get a feel for
+the language and the parser. Have implemented basic support for strings, numbers, bools, lists, maps,
+variables, and basic operators:
 
 ```shell
-cargo run -- --expression="size('hello world') > 5"
+cargo run -- --expression="size('hello world') > 5u"
 ```
 
 Outputs:
 ```
+CEL Expression:
+"size('hello world') > 5u"
+
+Context data:
+None
 AST: 
-Binary(Member(Var("size"), Call([Atom(String("hello world"))])), GreaterThan, Atom(Int(5)))
+Binary(Member(Var("size"), Call([Atom(String("hello world"))])), GreaterThan, Atom(UInt(5)))
 
 Evaluating program
 Bool(true)
+
 ```
 
 
-## References
+# References
 
-Real parsers using Chumsky:
+## Existing CEL Implementations
+
+- [cel-go](https://github.com/google/cel-go) - Reference implementation of CEL by Google in Go.
+- [cel-python](https://github.com/cloud-custodian/cel-python) - Python implementation of CEL by Cloud Custodian 
+  as used in [Netchecks](https://github.com/hardbyte/netchecks).
+- [clarkmcc/cel-rust](https://github.com/clarkmcc/cel-rust) (Maintained fork of [orf/cel-rust](https://github.com/orf/cel-rust).)
+  Implements separate crates for parser (using lalrpop) and interpreter (straightforward treewalk interpreter).
+- [thesayyn/cel-rust](https://github.com/thesayyn/cel-rust) (Incomplete). WASM target with online [demo](https://thesayyn.github.io/cel-rust/).
+  Parser uses lalrpop.
+
+Test Data
+
+https://github.com/google/cel-spec/blob/master/tests/simple/testdata/basic.textproto
+
+## Real parsers using Chumsky
+
 - [jaq](https://github.com/01mf02/jaq/blob/main/jaq-parse/src/token.rs)
 - https://github.com/panda-re/panda/blob/dev/panda/plugins/cosi_strace/src/c_type_parser.rs
 - [prql](https://github.com/PRQL/prql/blob/main/prql-compiler/src/parser) (uses a separate Chumsky Lexer to create Vec<Token>, then parses Token stream into Expr, Stmt, Literal etc)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,8 +4,8 @@ use std::io;
 use std::io::Read;
 use std::rc::Rc;
 
-use cel_interpreter::{eval, map_json_text_to_cel_types};
 use cel_interpreter::types::{CelMap, CelMapKey, CelType, NumericCelType};
+use cel_interpreter::{eval, map_json_text_to_cel_types};
 use cel_parser::parse_cel_expression;
 use clap::Parser as ClapParser;
 
@@ -28,26 +28,23 @@ struct Cli {
 fn main() {
     let app = Cli::parse();
 
-
     // Read the context (from stdin or a JSON file)
 
     // Note the as_deref maps the app.input's Option<String> to Option<str>
     let context_filename: Option<&str> = app.input.as_deref();
 
     let context = context_filename
-        .map(|filename|
-            load_context(filename).expect("Error loading context file")
-            )
+        .map(|filename| load_context(filename).expect("Error loading context file"))
         .map(|json_data| {
             // Map the json string of context into CelType::Map
             let context_result: Result<CelType, String> = map_json_text_to_cel_types(&json_data);
             context_result.expect("Error parsing context data")
-        }).unwrap_or_else(|| _create_empty_cel_map());
+        })
+        .unwrap_or_else(|| _create_empty_cel_map());
 
     let src = app.expression.to_string();
     println!("Context: {:?}", context);
     println!("CEL Expression:\n{:?}\n", src);
-
 
     match parse_cel_expression(src) {
         Ok(ast) => {
@@ -98,7 +95,9 @@ fn main() {
 }
 
 fn _create_empty_cel_map() -> CelType {
-    CelType::Map(CelMap { map: Rc::new(HashMap::new()) })
+    CelType::Map(CelMap {
+        map: Rc::new(HashMap::new()),
+    })
 }
 
 /// Load data from a file or stdin

--- a/examples/basic-json-object.json
+++ b/examples/basic-json-object.json
@@ -1,3 +1,14 @@
 {
-  "mykey": "my value"
+  "foo": "bar",
+  "string key": "my value",
+  "int key": 42,
+  "float key": 3.14,
+  "nested object": {
+    "nested key": 1
+  },
+  "array key": [
+    {
+      "a bool": true
+    }
+  ]
 }

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 cel-parser = { path = "../parser" }
 serde = {version = "1.0.171", features = ["derive"]}
+serde_json = "1.0.104"

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -1,9 +1,9 @@
 use cel_parser::ast::{BinaryOp, Expr, MemberOp, UnaryOp};
+use serde_json;
+use serde_json::{Number, Value};
 use std::collections::HashMap;
 use std::rc::Rc;
 use types::{CelFunction, CelMap, CelMapKey, CelType, NumericCelType};
-use serde_json;
-use serde_json::{Number, Value};
 
 // TODO should this really be public?
 mod strings;
@@ -200,7 +200,6 @@ pub fn eval<'a>(expr: &'a Expr, vars: &mut Vec<(&'a String, CelType)>) -> Result
     }
 }
 
-
 /** Load JSON from a string and convert it into CelTypes.
 
 Internally this uses serde_json to parse the string into Serde's internal
@@ -225,11 +224,9 @@ pub fn json_to_cel(data: Value) -> CelType {
         Value::Bool(v) => CelType::Bool(v),
         Value::Number(v) => CelType::NumericCelType(serde_json_number_to_numeric_cel_type(v)),
         Value::String(s) => CelType::String(Rc::new(s)),
-        Value::Array(v) => CelType::List(Rc::new(
-            v.iter()
-                .map(|v| json_to_cel(v.clone()))
-                .collect(),
-        )),
+        Value::Array(v) => {
+            CelType::List(Rc::new(v.iter().map(|v| json_to_cel(v.clone())).collect()))
+        }
         Value::Object(v) => CelType::Map(CelMap {
             map: Rc::new(
                 v.iter()

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -2,6 +2,8 @@ use cel_parser::ast::{BinaryOp, Expr, MemberOp, UnaryOp};
 use std::collections::HashMap;
 use std::rc::Rc;
 use types::{CelFunction, CelMap, CelMapKey, CelType, NumericCelType};
+use serde_json;
+use serde_json::{Number, Value};
 
 // TODO should this really be public?
 mod strings;
@@ -35,6 +37,7 @@ pub fn eval<'a>(expr: &'a Expr, vars: &mut Vec<(&'a String, CelType)>) -> Result
                     }),
                 }));
             }
+
             // Macros are not supported yet
             if name == "has" {
                 return Err(format!("Macro '{}' not implemented", name));
@@ -194,5 +197,63 @@ pub fn eval<'a>(expr: &'a Expr, vars: &mut Vec<(&'a String, CelType)>) -> Result
             }
         }
         _ => Err(format!("Need to handle member operation")),
+    }
+}
+
+
+/** Load JSON from a string and convert it into CelTypes.
+
+Internally this uses serde_json to parse the string into Serde's internal
+representation of JSON. We then recursively convert the values into CelTypes.
+*/
+pub fn map_json_text_to_cel_types(raw_data: &str) -> Result<CelType, String> {
+    // First load the file into serde_json's internal representation Value
+    let data: Value = serde_json::from_str(&raw_data).map_err(|e| format!("{}", e))?;
+
+    println!("Parsed context data: {:?}", data);
+
+    // Now convert the Value enum into the CelType enum
+    let cel_data = json_to_cel(data);
+
+    Ok(cel_data)
+}
+
+/// Map JSON data from Serde JSON to CelType
+pub fn json_to_cel(data: Value) -> CelType {
+    match data {
+        Value::Null => CelType::Null,
+        Value::Bool(v) => CelType::Bool(v),
+        Value::Number(v) => CelType::NumericCelType(serde_json_number_to_numeric_cel_type(v)),
+        Value::String(s) => CelType::String(Rc::new(s)),
+        Value::Array(v) => CelType::List(Rc::new(
+            v.iter()
+                .map(|v| json_to_cel(v.clone()))
+                .collect(),
+        )),
+        Value::Object(v) => CelType::Map(CelMap {
+            map: Rc::new(
+                v.iter()
+                    .map(|(k, v)| {
+                        (
+                            // Note keys from JSON are always strings
+                            CelMapKey::String(Rc::new(k.clone())),
+                            json_to_cel(v.clone()),
+                        )
+                    })
+                    .collect(),
+            ),
+        }),
+    }
+}
+
+fn serde_json_number_to_numeric_cel_type(n: Number) -> NumericCelType {
+    if n.is_i64() {
+        NumericCelType::Int(n.as_i64().unwrap())
+    } else if n.is_u64() {
+        NumericCelType::UInt(n.as_u64().unwrap())
+    } else if n.is_f64() {
+        NumericCelType::Float(n.as_f64().unwrap())
+    } else {
+        panic!("Unexpected number type")
     }
 }


### PR DESCRIPTION
Context loading, implement JSON-parsing to CEL types

Refactored to streamline the loading of context from stdin or a JSON file. CLI now parses JSON from either stdin or a file and converts to CEL's own types. Note the context isn't currently available for the CEL expression - I want to create an abstraction like Environment or Context first.

The 'map_json_text_to_cel_types' function was added to lib.rs in the interpreter module. This function uses the serde_json library to parse JSON strings and map them to corresponding CEL types.

The basic-json-object.json file in the examples directory was also updated to accommodate more comprehensive use cases involving different data types and nested structures.