### PR TITLE
Feature/recursive member

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ Evaluating program
 NumericCelType(Float(-15.0))
 ```
 
-Note the parser is not complete, so it will fail on some valid expressions. At this stage I'm not
-intending to implement a full interpreter with all built-in functions, just enough to get a feel for
-the language and the parser. Have implemented basic support for strings, numbers, bools, lists, maps,
-variables, and basic operators:
+Note the parser is not complete, so it will fail on some valid expressions including
+Durations. At this stage I'm not intending to implement a full interpreter with all
+built-in functions, just enough to get a feel for the language and the parser. Have
+implemented basic support for strings, numbers, bools, lists, maps, variables, and
+basic operators:
 
 ```shell
 cargo run -- --expression="size('hello world') > 5u"

--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ Evaluating program
 NumericCelType(Float(-15.0))
 ```
 
-Note the parser is not complete, so it will fail on some valid expressions including
-Durations. At this stage I'm not intending to implement a full interpreter with all
-built-in functions, just enough to get a feel for the language and the parser. Have
-implemented basic support for strings, numbers, bools, lists, maps, variables, and
-basic operators:
+Note while the parser is close to complete I'm not intending to implement a full interpreter
+with all built-in functions.
+
+The interpreter has basic support for strings, numbers, bools, lists, maps, variables, and
+binary and unary operators.
+
 
 ```shell
 cargo run -- --expression="size('hello world') > 5u"

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -253,7 +253,7 @@ pub fn eval<'a>(
                     evaluated_lhs
                 )),
             }
-            //Err(format!("Need to handle member operation"))
+
         }
         Expression::Member(lhs, Member::FunctionCall(args)) => {
             let evaluated_lhs = eval(lhs, vars)?;
@@ -270,7 +270,42 @@ pub fn eval<'a>(
                 _ => Err(format!("Can't call this type")),
             }
         }
-        _ => Err(format!("Need to handle member operation")),
+        Expression::And(lhs, rhs) => {
+            let evaluated_lhs = eval(lhs, vars)?;
+            match evaluated_lhs {
+                CelType::Bool(b) => {
+                    if b {
+                        let evaluated_rhs = eval(rhs, vars)?;
+                        match evaluated_rhs {
+                            CelType::Bool(b) => Ok(CelType::Bool(b)),
+                            _ => Err(format!("Can't AND a bool with {:?}", evaluated_rhs)),
+                        }
+                    } else {
+                        Ok(CelType::Bool(false))
+                    }
+                },
+                _ => Err(format!("Can't AND a {:?}", evaluated_lhs)),
+            }
+        }
+        Expression::Or(lhs, rhs) => {
+            let evaluated_lhs = eval(lhs, vars)?;
+            match evaluated_lhs {
+                CelType::Bool(b) => {
+                    if b {
+                        Ok(CelType::Bool(true))
+                    } else {
+                        let evaluated_rhs = eval(rhs, vars)?;
+                        match evaluated_rhs {
+                            CelType::Bool(b) => Ok(CelType::Bool(b)),
+                            _ => Err(format!("Can't OR a bool with {:?}", evaluated_rhs)),
+                        }
+                    }
+                },
+                _ => Err(format!("Can't OR a {:?}", evaluated_lhs))
+            }
+        }
+
+        _ => Err(format!("Need to handle expression {:?}", expr)),
     }
 }
 

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -303,6 +303,19 @@ pub fn eval<'a>(
                 },
                 _ => Err(format!("Can't OR a {:?}", evaluated_lhs))
             }
+        },
+        Expression::Ternary(condition, true_expression, false_expression) => {
+            let evaluated_condition = eval(condition, vars)?;
+            match evaluated_condition {
+                CelType::Bool(b) => {
+                    if b {
+                        eval(true_expression, vars)
+                    } else {
+                        eval(false_expression, vars)
+                    }
+                },
+                _ => Err(format!("Ternary condition must be a bool, got {:?}", evaluated_condition)),
+            }
         }
 
         _ => Err(format!("Need to handle expression {:?}", expr)),

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -9,7 +9,10 @@ use types::{CelFunction, CelMap, CelMapKey, CelType, NumericCelType};
 mod strings;
 pub mod types;
 
-pub fn eval<'a>(expr: &'a Expression, vars: &mut Vec<(&'a String, CelType)>) -> Result<CelType, String> {
+pub fn eval<'a>(
+    expr: &'a Expression,
+    vars: &mut Vec<(&'a String, CelType)>,
+) -> Result<CelType, String> {
     match expr {
         Expression::Atom(atom) => Ok(atom.into()),
         Expression::Ident(name) => {
@@ -74,7 +77,10 @@ pub fn eval<'a>(expr: &'a Expression, vars: &mut Vec<(&'a String, CelType)>) -> 
                 (CelType::String(a), CelType::String(b)) => match op {
                     RelationOp::Equals => Ok(CelType::Bool(a == b)),
                     RelationOp::NotEquals => Ok(CelType::Bool(a != b)),
-                    _ => Err(format!("Binary operation {:?} not supported for String", op)),
+                    _ => Err(format!(
+                        "Binary operation {:?} not supported for String",
+                        op
+                    )),
                 },
                 (CelType::NumericCelType(a), CelType::NumericCelType(b)) => match op {
                     // Here we know that both the lhs and rhs are of type CelType::NumericCelType
@@ -90,9 +96,12 @@ pub fn eval<'a>(expr: &'a Expression, vars: &mut Vec<(&'a String, CelType)>) -> 
                     RelationOp::NotEquals => Ok(CelType::Bool(a != b)),
                     _ => Err(format!("Unsupported list operation {:?}", op)),
                 },
-                (_, _) => Err(format!("Unsupported relation between {:?} and {:?}", lhs, rhs)),
+                (_, _) => Err(format!(
+                    "Unsupported relation between {:?} and {:?}",
+                    lhs, rhs
+                )),
             }
-        },
+        }
 
         Expression::Arithmetic(lhs, op, rhs) => {
             let eval_lhs = eval(lhs, vars)?;

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -90,6 +90,29 @@ pub fn eval<'a>(
                     RelationOp::LessThanOrEqual => Ok(CelType::Bool(a <= b)),
                     RelationOp::GreaterThan => Ok(CelType::Bool(a > b)),
                     RelationOp::GreaterThanOrEqual => Ok(CelType::Bool(a >= b)),
+                    RelationOp::In => Err(format!(
+                        "Unsupported operation 'in' between numerical types"
+                    )),
+                },
+                (a, CelType::List(b)) => match op {
+                    RelationOp::In => {
+                        // Is a in list b
+                        Ok(CelType::Bool(b.contains(&a)))
+                    }
+                    _ => Err(format!(
+                        "Unsupported operation {:?} between {:?} and {:?}",
+                        op, a, b
+                    )),
+                },
+                (a, CelType::Map(b)) => match op {
+                    RelationOp::In => {
+                        // Is a in list b. Note the `into()` converts a to a CelMapKey
+                        Ok(CelType::Bool(b.map.contains_key(&a.into())))
+                    }
+                    _ => Err(format!(
+                        "Unsupported operation {:?} between {:?} and {:?}",
+                        op, a, b
+                    )),
                 },
                 (CelType::List(a), CelType::List(b)) => match op {
                     RelationOp::Equals => Ok(CelType::Bool(a == b)),

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -253,7 +253,6 @@ pub fn eval<'a>(
                     evaluated_lhs
                 )),
             }
-
         }
         Expression::Member(lhs, Member::FunctionCall(args)) => {
             let evaluated_lhs = eval(lhs, vars)?;
@@ -283,7 +282,7 @@ pub fn eval<'a>(
                     } else {
                         Ok(CelType::Bool(false))
                     }
-                },
+                }
                 _ => Err(format!("Can't AND a {:?}", evaluated_lhs)),
             }
         }
@@ -300,10 +299,10 @@ pub fn eval<'a>(
                             _ => Err(format!("Can't OR a bool with {:?}", evaluated_rhs)),
                         }
                     }
-                },
-                _ => Err(format!("Can't OR a {:?}", evaluated_lhs))
+                }
+                _ => Err(format!("Can't OR a {:?}", evaluated_lhs)),
             }
-        },
+        }
         Expression::Ternary(condition, true_expression, false_expression) => {
             let evaluated_condition = eval(condition, vars)?;
             match evaluated_condition {
@@ -313,8 +312,11 @@ pub fn eval<'a>(
                     } else {
                         eval(false_expression, vars)
                     }
-                },
-                _ => Err(format!("Ternary condition must be a bool, got {:?}", evaluated_condition)),
+                }
+                _ => Err(format!(
+                    "Ternary condition must be a bool, got {:?}",
+                    evaluated_condition
+                )),
             }
         }
 
@@ -479,6 +481,63 @@ mod tests {
         assert_eq!(
             evaluate_cel_expression("size('hello') == 5u"),
             CelType::Bool(true)
+        );
+    }
+
+    #[test]
+    fn test_evaluate_and() {
+        assert_eq!(evaluate_cel_expression("true && true"), CelType::Bool(true));
+
+        assert_eq!(
+            evaluate_cel_expression("true && false"),
+            CelType::Bool(false)
+        );
+        assert_eq!(
+            evaluate_cel_expression("false && true"),
+            CelType::Bool(false)
+        );
+    }
+    #[test]
+    fn test_evaluate_or() {
+        assert_eq!(evaluate_cel_expression("true || true"), CelType::Bool(true));
+
+        assert_eq!(
+            evaluate_cel_expression("true || false"),
+            CelType::Bool(true)
+        );
+        assert_eq!(
+            evaluate_cel_expression("false || true"),
+            CelType::Bool(true)
+        );
+        assert_eq!(
+            evaluate_cel_expression("false || false"),
+            CelType::Bool(false)
+        );
+    }
+
+    #[test]
+    fn test_evaluate_ternary() {
+        assert_eq!(
+            evaluate_cel_expression("true ? 'result_true' : 'result_false'"),
+            CelType::String("result_true".to_string().into())
+        );
+
+        assert_eq!(
+            evaluate_cel_expression("false ? 'result_true' : 'result_false'"),
+            CelType::String("result_false".to_string().into())
+        );
+
+        assert_eq!(
+            evaluate_cel_expression("1 == 1 ? 'result_true' : 'result_false'"),
+            CelType::String("result_true".to_string().into())
+        );
+    }
+
+    #[test]
+    fn test_evaluate_ternary_numeric() {
+        assert_eq!(
+            evaluate_cel_expression("true ? 100 : 200"),
+            CelType::NumericCelType(NumericCelType::Int(100))
         );
     }
 

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -1,4 +1,4 @@
-use cel_parser::ast::{BinaryOp, Expression, MemberOp, UnaryOp};
+use cel_parser::ast::{ArithmeticOp, Expression, MemberOp, UnaryOp};
 use serde_json;
 use serde_json::{Number, Value};
 use std::collections::HashMap;
@@ -72,9 +72,9 @@ pub fn eval<'a>(expr: &'a Expression, vars: &mut Vec<(&'a String, CelType)>) -> 
             // regardless of the sides' types.
             match (eval_lhs, eval_rhs) {
                 (CelType::String(a), CelType::String(b)) => match op {
-                    BinaryOp::Add => Ok(CelType::String(Rc::new(format!("{}{}", a, b)))),
-                    BinaryOp::Equals => Ok(CelType::Bool(a == b)),
-                    BinaryOp::NotEquals => Ok(CelType::Bool(a != b)),
+                    ArithmeticOp::Add => Ok(CelType::String(Rc::new(format!("{}{}", a, b)))),
+                    ArithmeticOp::Equals => Ok(CelType::Bool(a == b)),
+                    ArithmeticOp::NotEquals => Ok(CelType::Bool(a != b)),
                     _ => Err(format!(
                         "Binary operation {:?} not supported for String",
                         op
@@ -82,26 +82,26 @@ pub fn eval<'a>(expr: &'a Expression, vars: &mut Vec<(&'a String, CelType)>) -> 
                 },
                 (CelType::NumericCelType(a), CelType::NumericCelType(b)) => match op {
                     // Here we know that both the lhs and rhs are of type CelType::NumericCelType
-                    BinaryOp::Mul => Ok(CelType::NumericCelType(a * b)),
-                    BinaryOp::Div => Ok(CelType::NumericCelType(a / b)),
-                    BinaryOp::Add => Ok(CelType::NumericCelType(a + b)),
-                    BinaryOp::Sub => Ok(CelType::NumericCelType(a - b)),
-                    BinaryOp::Equals => Ok(CelType::Bool(a == b)),
-                    BinaryOp::NotEquals => Ok(CelType::Bool(a != b)),
-                    BinaryOp::LessThan => Ok(CelType::Bool(a < b)),
-                    BinaryOp::LessThanOrEqual => Ok(CelType::Bool(a <= b)),
-                    BinaryOp::GreaterThan => Ok(CelType::Bool(a > b)),
-                    BinaryOp::GreaterThanOrEqual => Ok(CelType::Bool(a >= b)),
+                    ArithmeticOp::Multiply => Ok(CelType::NumericCelType(a * b)),
+                    ArithmeticOp::Divide => Ok(CelType::NumericCelType(a / b)),
+                    ArithmeticOp::Add => Ok(CelType::NumericCelType(a + b)),
+                    ArithmeticOp::Subtract => Ok(CelType::NumericCelType(a - b)),
+                    ArithmeticOp::Equals => Ok(CelType::Bool(a == b)),
+                    ArithmeticOp::NotEquals => Ok(CelType::Bool(a != b)),
+                    ArithmeticOp::LessThan => Ok(CelType::Bool(a < b)),
+                    ArithmeticOp::LessThanOrEqual => Ok(CelType::Bool(a <= b)),
+                    ArithmeticOp::GreaterThan => Ok(CelType::Bool(a > b)),
+                    ArithmeticOp::GreaterThanOrEqual => Ok(CelType::Bool(a >= b)),
                 },
                 (CelType::List(a), CelType::List(b)) => match op {
-                    BinaryOp::Add => {
+                    ArithmeticOp::Add => {
                         let mut output: Vec<CelType> = Vec::with_capacity(a.len() + b.len());
                         output.extend_from_slice(&a);
                         output.extend_from_slice(&b);
                         Ok(CelType::List(Rc::new(output)))
                     }
-                    BinaryOp::Equals => Ok(CelType::Bool(a == b)),
-                    BinaryOp::NotEquals => Ok(CelType::Bool(a != b)),
+                    ArithmeticOp::Equals => Ok(CelType::Bool(a == b)),
+                    ArithmeticOp::NotEquals => Ok(CelType::Bool(a != b)),
                     _ => Err(format!("Unsupported list operation {:?}", op)),
                 },
                 (_, _) => Err(format!(

--- a/interpreter/src/strings.rs
+++ b/interpreter/src/strings.rs
@@ -1,23 +1,15 @@
 use crate::types::NumericCelType;
+use crate::utils::usize_from_cel_number;
 
 pub fn str_index_from_cel_number(
     cel_index: &NumericCelType,
     strlen: usize,
 ) -> Result<usize, String> {
-    let index = match cel_index {
-        NumericCelType::Int(i) if *i >= 0 => *i as usize,
-        NumericCelType::UInt(i) => *i as usize,
-        _ => {
-            return Err(format!(
-                "Index must be a positive integer, not {:?}",
-                cel_index
-            ))
-        }
-    };
+    let index = usize_from_cel_number(cel_index)?;
 
     if index > (strlen) {
         return Err(format!(
-            "Index {} out of bounds for string of length {}",
+            "Index {} out of bounds. String length {}",
             index, strlen
         ));
     }

--- a/interpreter/src/types.rs
+++ b/interpreter/src/types.rs
@@ -160,7 +160,7 @@ impl From<&Atom> for CelType {
         match atom {
             Atom::Int(i) => CelType::NumericCelType(NumericCelType::Int(*i)),
             Atom::UInt(ui) => CelType::NumericCelType(NumericCelType::UInt(*ui)),
-            Atom::Double(f) => CelType::NumericCelType(NumericCelType::Float(*f)),
+            Atom::Float(f) => CelType::NumericCelType(NumericCelType::Float(*f)),
             Atom::Bool(b) => CelType::Bool(*b),
             Atom::Bytes(b) => CelType::Bytes(b.clone()),
             Atom::Null => CelType::Null,

--- a/interpreter/src/utils.rs
+++ b/interpreter/src/utils.rs
@@ -1,0 +1,14 @@
+use crate::types::NumericCelType;
+
+pub fn usize_from_cel_number(cel_index: &NumericCelType) -> Result<usize, String> {
+    match cel_index {
+        NumericCelType::Int(i) if *i >= 0 => Ok(*i as usize),
+        NumericCelType::UInt(i) => Ok(*i as usize),
+        _ => {
+            return Err(format!(
+                "Index must be a positive integer, not {:?}",
+                cel_index
+            ))
+        }
+    }
+}

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -35,6 +35,7 @@ pub enum RelationOp {
     GreaterThanOrEqual,
     LessThan,
     LessThanOrEqual,
+    In,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 pub enum Atom {
     Int(i64),
     UInt(u64),
-    Double(f64),
+    Float(f64),
     // A reference counted String
     String(Rc<String>),
     Bytes(Rc<Vec<u8>>),
@@ -25,9 +25,11 @@ pub enum ArithmeticOp {
     Multiply,
     Divide,
 
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum RelationOp {
     // "<" | "<=" | ">=" | ">" | "==" | "!=" | "in"
-    // Could be BinaryRel instead, but not sure if that's necessary
-    // In,
     NotEquals,
     Equals,
     GreaterThan,
@@ -37,24 +39,25 @@ pub enum ArithmeticOp {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum MemberOp {
+pub enum Member {
     // a.b, a[b, c...], a(b, c, ...)
     Attribute(String),
+    FunctionCall(Vec<Expression>),
     Index(Vec<Expression>),
-    Call(Vec<Expression>),
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Expression {
     Atom(Atom),
 
-    Var(String),
+    Ident(String),
 
-    Member(Box<Expression>, MemberOp),
+    Member(Box<Expression>, Member),
 
     Unary(UnaryOp, Box<Expression>),
 
-    Binary(Box<Expression>, ArithmeticOp, Box<Expression>),
+    Arithmetic(Box<Expression>, ArithmeticOp, Box<Expression>),
+    Relation(Box<Expression>, RelationOp, Box<Expression>),
 
     List(Vec<Expression>),
 

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -40,24 +40,24 @@ pub enum BinaryOp {
 pub enum MemberOp {
     // a.b, a[b, c...], a(b, c, ...)
     Attribute(String),
-    Index(Vec<Expr>),
-    Call(Vec<Expr>),
+    Index(Vec<Expression>),
+    Call(Vec<Expression>),
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum Expr {
+pub enum Expression {
     Atom(Atom),
 
     Var(String),
 
-    Member(Box<Expr>, MemberOp),
+    Member(Box<Expression>, MemberOp),
 
-    Unary(UnaryOp, Box<Expr>),
+    Unary(UnaryOp, Box<Expression>),
 
-    Binary(Box<Expr>, BinaryOp, Box<Expr>),
+    Binary(Box<Expression>, BinaryOp, Box<Expression>),
 
-    List(Vec<Expr>),
+    List(Vec<Expression>),
 
     // Associative arrays with int, uint, bool, or string keys
-    Map(Vec<(Expr, Expr)>),
+    Map(Vec<(Expression, Expression)>),
 }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -48,6 +48,14 @@ pub enum Member {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Expression {
+    Arithmetic(Box<Expression>, ArithmeticOp, Box<Expression>),
+    Relation(Box<Expression>, RelationOp, Box<Expression>),
+
+    Ternary(Box<Expression>, Box<Expression>, Box<Expression>),
+
+    Or(Box<Expression>, Box<Expression>),
+    And(Box<Expression>, Box<Expression>),
+
     Atom(Atom),
 
     Ident(String),
@@ -55,12 +63,6 @@ pub enum Expression {
     Member(Box<Expression>, Member),
 
     Unary(UnaryOp, Box<Expression>),
-
-    Arithmetic(Box<Expression>, ArithmeticOp, Box<Expression>),
-    Relation(Box<Expression>, RelationOp, Box<Expression>),
-
-    Or(Box<Expression>, Box<Expression>),
-    And(Box<Expression>, Box<Expression>),
 
     List(Vec<Expression>),
 

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -24,7 +24,6 @@ pub enum ArithmeticOp {
     Subtract,
     Multiply,
     Divide,
-
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -58,6 +58,9 @@ pub enum Expression {
     Arithmetic(Box<Expression>, ArithmeticOp, Box<Expression>),
     Relation(Box<Expression>, RelationOp, Box<Expression>),
 
+    Or(Box<Expression>, Box<Expression>),
+    And(Box<Expression>, Box<Expression>),
+
     List(Vec<Expression>),
 
     // Associative arrays with int, uint, bool, or string keys

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -43,7 +43,7 @@ pub enum Member {
     // a.b, a[b, c...], a(b, c, ...)
     Attribute(String),
     FunctionCall(Vec<Expression>),
-    Index(Vec<Expression>),
+    Index(Box<Expression>),
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -19,11 +19,11 @@ pub enum UnaryOp {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub enum BinaryOp {
+pub enum ArithmeticOp {
     Add,
-    Sub,
-    Mul,
-    Div,
+    Subtract,
+    Multiply,
+    Divide,
 
     // "<" | "<=" | ">=" | ">" | "==" | "!=" | "in"
     // Could be BinaryRel instead, but not sure if that's necessary
@@ -54,7 +54,7 @@ pub enum Expression {
 
     Unary(UnaryOp, Box<Expression>),
 
-    Binary(Box<Expression>, BinaryOp, Box<Expression>),
+    Binary(Box<Expression>, ArithmeticOp, Box<Expression>),
 
     List(Vec<Expression>),
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -3,7 +3,7 @@ pub mod parser;
 use chumsky::error::Simple;
 use chumsky::Parser;
 
-pub fn parse_cel_expression(input: String) -> Result<ast::Expr, Vec<Simple<char>>> {
+pub fn parse_cel_expression(input: String) -> Result<ast::Expression, Vec<Simple<char>>> {
     // Expose the internal parser::parse function
     parser::parser().parse(input)
 }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -357,7 +357,7 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
         let function_call = just('(')
             .ignore_then(expr_list.clone())
             .then_ignore(just(')'))
-            .map(|args| Member::FunctionCall(args))
+            .map(|args: Vec<Expression>| Member::FunctionCall(args))
             .labelled("primary function call");
 
         // TODO this moves to member
@@ -374,7 +374,7 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
             .clone()
             // Ignore trailing comma
             .delimited_by(just('['), just(']'))
-            .map(|items| Expression::List(items))
+            .map(|items: Vec<Expression>| Expression::List(items))
             .labelled("list");
 
         let map_item = expr
@@ -472,7 +472,8 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
             .or(just(">=").to(RelationOp::GreaterThanOrEqual))
             .or(just("<=").to(RelationOp::LessThanOrEqual))
             .or(just('>').to(RelationOp::GreaterThan))
-            .or(just('<').to(RelationOp::LessThan));
+            .or(just('<').to(RelationOp::LessThan))
+            .or(just("in").to(RelationOp::In));
 
         let relation = addition
             .clone()

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -306,7 +306,19 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
             .foldl(|lhs, (op, rhs)| Expression::Relation(Box::new(lhs), op, Box::new(rhs)))
             .labelled("comparison");
 
-        relation
+        let conditional_and = relation
+            .clone()
+            .then(just("&&").then(relation.clone()).repeated())
+            .foldl(|lhs, (_op, rhs)| Expression::And(Box::new(lhs), Box::new(rhs)))
+            .labelled("conditional and");
+
+        let conditional_or = conditional_and
+            .clone()
+            .then(just("||").then(conditional_and.clone()).repeated())
+            .foldl(|lhs, (_op, rhs)| Expression::Or(Box::new(lhs), Box::new(rhs)))
+            .labelled("conditional or");
+
+        conditional_or
     });
 
     expr.clone()

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Atom, ArithmeticOp, Expression, Member, UnaryOp, RelationOp};
+use crate::ast::{ArithmeticOp, Atom, Expression, Member, RelationOp, UnaryOp};
 
 use chumsky::prelude::*;
 use chumsky::Parser;
@@ -12,8 +12,14 @@ fn boolean() -> impl Parser<char, Expression, Error = Simple<char>> {
 
 #[test]
 fn test_boolean_parser() {
-    assert_eq!(boolean().parse("true"), Ok(Expression::Atom(Atom::Bool(true))));
-    assert_eq!(boolean().parse("false"), Ok(Expression::Atom(Atom::Bool(false))));
+    assert_eq!(
+        boolean().parse("true"),
+        Ok(Expression::Atom(Atom::Bool(true)))
+    );
+    assert_eq!(
+        boolean().parse("false"),
+        Ok(Expression::Atom(Atom::Bool(false)))
+    );
     assert!(boolean().parse("tru").is_err());
     assert!(boolean().parse("False").is_err());
 }
@@ -82,12 +88,18 @@ fn test_number_parser_int() {
     // Debatable if this should be allowed. Ref CEL Spec:
     // https://github.com/google/cel-spec/blob/master/doc/langdef.md#numeric-values
     // "negative integers are produced by the unary negation operator"
-    assert_eq!(numbers().parse("-100"), Ok(Expression::Atom(Atom::Int(-100))));
+    assert_eq!(
+        numbers().parse("-100"),
+        Ok(Expression::Atom(Atom::Int(-100)))
+    );
 }
 
 #[test]
 fn test_number_parser_double() {
-    assert_eq!(numbers().parse("1e3"), Ok(Expression::Atom(Atom::Float(1000.0))));
+    assert_eq!(
+        numbers().parse("1e3"),
+        Ok(Expression::Atom(Atom::Float(1000.0)))
+    );
     assert_eq!(
         numbers().parse("-1e-3"),
         Ok(Expression::Atom(Atom::Float(-0.001)))
@@ -248,11 +260,15 @@ fn test_str_inner_parser() {
 fn test_str_parser() {
     assert_eq!(
         str_().parse("'Hello!'"),
-        Ok(Expression::Atom(Atom::String(String::from("Hello!").into())))
+        Ok(Expression::Atom(Atom::String(
+            String::from("Hello!").into()
+        )))
     );
     assert_eq!(
         str_().parse("\"Hello!\""),
-        Ok(Expression::Atom(Atom::String(String::from("Hello!").into())))
+        Ok(Expression::Atom(Atom::String(
+            String::from("Hello!").into()
+        )))
     );
     assert_eq!(
         str_().parse("'\n'"),
@@ -290,11 +306,15 @@ fn test_raw_str_parser() {
     );
     assert_eq!(
         str_().parse("r\"Hello!\""),
-        Ok(Expression::Atom(Atom::String(String::from("Hello!").into())))
+        Ok(Expression::Atom(Atom::String(
+            String::from("Hello!").into()
+        )))
     );
     assert_eq!(
         str_().parse("R\"Hello!\""),
-        Ok(Expression::Atom(Atom::String(String::from("Hello!").into())))
+        Ok(Expression::Atom(Atom::String(
+            String::from("Hello!").into()
+        )))
     );
     assert_eq!(
         str_().parse(r"r'''hello'''"),
@@ -422,16 +442,22 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
             .boxed()
             .labelled("unary");
 
-        let product_div_op = op('*').to(ArithmeticOp::Multiply).or(op('/').to(ArithmeticOp::Divide));
+        let product_div_op = op('*')
+            .to(ArithmeticOp::Multiply)
+            .or(op('/').to(ArithmeticOp::Divide));
 
         let multiplication = unary
             .clone()
             .then(product_div_op.then(unary.clone()).repeated())
-            .foldl(|lhs, (binary_op, rhs)| Expression::Arithmetic(Box::new(lhs), binary_op, Box::new(rhs)))
+            .foldl(|lhs, (binary_op, rhs)| {
+                Expression::Arithmetic(Box::new(lhs), binary_op, Box::new(rhs))
+            })
             .labelled("product_or_division")
             .boxed();
 
-        let sum_sub_op = op('+').to(ArithmeticOp::Add).or(op('-').to(ArithmeticOp::Subtract));
+        let sum_sub_op = op('+')
+            .to(ArithmeticOp::Add)
+            .or(op('-').to(ArithmeticOp::Subtract));
 
         let addition = multiplication
             .clone()
@@ -463,8 +489,14 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
 
 #[test]
 fn test_parser_bool() {
-    assert_eq!(parser().parse("true"), Ok(Expression::Atom(Atom::Bool(true))));
-    assert_eq!(parser().parse("false"), Ok(Expression::Atom(Atom::Bool(false))));
+    assert_eq!(
+        parser().parse("true"),
+        Ok(Expression::Atom(Atom::Bool(true)))
+    );
+    assert_eq!(
+        parser().parse("false"),
+        Ok(Expression::Atom(Atom::Bool(false)))
+    );
     assert_eq!(
         parser().parse("!false"),
         Ok(Expression::Unary(
@@ -506,7 +538,9 @@ fn test_parser_str() {
 
     assert_eq!(
         parser().parse("'''true\n'''"),
-        Ok(Expression::Atom(Atom::String(String::from("true\n").into())))
+        Ok(Expression::Atom(Atom::String(
+            String::from("true\n").into()
+        )))
     );
     assert_eq!(
         parser().parse(r##""""He said "Hi I'm Brian".""""##),
@@ -528,7 +562,10 @@ fn test_parser_raw_strings() {
 fn test_parser_positive_numbers() {
     assert_eq!(parser().parse("1"), Ok(Expression::Atom(Atom::Int(1))));
     assert_eq!(parser().parse("1u"), Ok(Expression::Atom(Atom::UInt(1))));
-    assert_eq!(parser().parse("1.0"), Ok(Expression::Atom(Atom::Float(1.0))));
+    assert_eq!(
+        parser().parse("1.0"),
+        Ok(Expression::Atom(Atom::Float(1.0)))
+    );
 }
 
 #[test]

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,19 +1,19 @@
-use crate::ast::{Atom, BinaryOp, Expr, MemberOp, UnaryOp};
+use crate::ast::{Atom, BinaryOp, Expression, MemberOp, UnaryOp};
 
 use chumsky::prelude::*;
 use chumsky::Parser;
 
-fn boolean() -> impl Parser<char, Expr, Error = Simple<char>> {
+fn boolean() -> impl Parser<char, Expression, Error = Simple<char>> {
     just("true")
         .to(true)
         .or(just("false").to(false))
-        .map(|b| Expr::Atom(Atom::Bool(b)))
+        .map(|b| Expression::Atom(Atom::Bool(b)))
 }
 
 #[test]
 fn test_boolean_parser() {
-    assert_eq!(boolean().parse("true"), Ok(Expr::Atom(Atom::Bool(true))));
-    assert_eq!(boolean().parse("false"), Ok(Expr::Atom(Atom::Bool(false))));
+    assert_eq!(boolean().parse("true"), Ok(Expression::Atom(Atom::Bool(true))));
+    assert_eq!(boolean().parse("false"), Ok(Expression::Atom(Atom::Bool(false))));
     assert!(boolean().parse("tru").is_err());
     assert!(boolean().parse("False").is_err());
 }
@@ -31,7 +31,7 @@ fn test_boolean_parser() {
 /// - `1E-10`
 /// - `-1e10`
 /// - `1u`
-fn numbers() -> impl Parser<char, Expr, Error = Simple<char>> {
+fn numbers() -> impl Parser<char, Expression, Error = Simple<char>> {
     let digits = text::digits::<char, Simple<char>>(10);
 
     let frac = just('.').chain::<char, _, _>(digits.clone().or_not());
@@ -50,9 +50,9 @@ fn numbers() -> impl Parser<char, Expr, Error = Simple<char>> {
             let str = chars.into_iter().collect::<String>();
 
             if let Ok(i) = str.parse::<i64>() {
-                Ok(Expr::Atom(Atom::Int(i)))
+                Ok(Expression::Atom(Atom::Int(i)))
             } else if let Ok(f) = str.parse::<f64>() {
-                Ok(Expr::Atom(Atom::Double(f)))
+                Ok(Expression::Atom(Atom::Double(f)))
             } else {
                 Err(Simple::expected_input_found(span, None, None))
             }
@@ -60,7 +60,7 @@ fn numbers() -> impl Parser<char, Expr, Error = Simple<char>> {
 
     let unsigned_integer = text::int::<char, Simple<char>>(10)
         .then_ignore(just('u'))
-        .map(|s: String| Expr::Atom(Atom::UInt(s.as_str().parse().unwrap())));
+        .map(|s: String| Expression::Atom(Atom::UInt(s.as_str().parse().unwrap())));
 
     choice((unsigned_integer, float_or_int))
         .padded()
@@ -71,30 +71,30 @@ fn numbers() -> impl Parser<char, Expr, Error = Simple<char>> {
 fn test_number_parser_unsigned_numbers() {
     //let unsigned_integer = text::int::<char, Simple<char>>(10).then_ignore(just('u')).map(|s: String| Expr::Atom(Atom::UInt(s.as_str().parse().unwrap())));
     //assert_eq!(unsigned_integer.parse("1u"), Ok(Expr::Atom(Atom::UInt(1))));
-    assert_eq!(numbers().parse("1u"), Ok(Expr::Atom(Atom::UInt(1))));
-    assert_eq!(numbers().parse("1up"), Ok(Expr::Atom(Atom::UInt(1))));
+    assert_eq!(numbers().parse("1u"), Ok(Expression::Atom(Atom::UInt(1))));
+    assert_eq!(numbers().parse("1up"), Ok(Expression::Atom(Atom::UInt(1))));
 }
 
 #[test]
 fn test_number_parser_int() {
-    assert_eq!(numbers().parse("1"), Ok(Expr::Atom(Atom::Int(1))));
+    assert_eq!(numbers().parse("1"), Ok(Expression::Atom(Atom::Int(1))));
 
     // Debatable if this should be allowed. Ref CEL Spec:
     // https://github.com/google/cel-spec/blob/master/doc/langdef.md#numeric-values
     // "negative integers are produced by the unary negation operator"
-    assert_eq!(numbers().parse("-100"), Ok(Expr::Atom(Atom::Int(-100))));
+    assert_eq!(numbers().parse("-100"), Ok(Expression::Atom(Atom::Int(-100))));
 }
 
 #[test]
 fn test_number_parser_double() {
-    assert_eq!(numbers().parse("1e3"), Ok(Expr::Atom(Atom::Double(1000.0))));
+    assert_eq!(numbers().parse("1e3"), Ok(Expression::Atom(Atom::Double(1000.0))));
     assert_eq!(
         numbers().parse("-1e-3"),
-        Ok(Expr::Atom(Atom::Double(-0.001)))
+        Ok(Expression::Atom(Atom::Double(-0.001)))
     );
     assert_eq!(
         numbers().parse("-1.4e-3"),
-        Ok(Expr::Atom(Atom::Double(-0.0014)))
+        Ok(Expression::Atom(Atom::Double(-0.0014)))
     );
 }
 
@@ -166,7 +166,7 @@ fn str_inner(
 // Ref https://github.com/01mf02/jaq/blob/main/jaq-parse/src/token.rs
 // See also https://github.com/PRQL/prql/blob/main/prql-compiler/src/parser/lexer.rs#L295-L354
 // A parser for strings; adapted from Chumsky's JSON example parser.
-fn str_() -> impl Parser<char, Expr, Error = Simple<char>> {
+fn str_() -> impl Parser<char, Expression, Error = Simple<char>> {
     let single_quoted_string = str_inner("'", true).labelled("single quoted string");
 
     let double_quoted_string = str_inner("\"", true).labelled("double quoted string");
@@ -202,7 +202,7 @@ fn str_() -> impl Parser<char, Expr, Error = Simple<char>> {
         double_quoted_raw_string,
         double_quoted_string,
     ))
-    .map(|s| Expr::Atom(Atom::String(s.into())))
+    .map(|s| Expression::Atom(Atom::String(s.into())))
 }
 
 #[test]
@@ -248,29 +248,29 @@ fn test_str_inner_parser() {
 fn test_str_parser() {
     assert_eq!(
         str_().parse("'Hello!'"),
-        Ok(Expr::Atom(Atom::String(String::from("Hello!").into())))
+        Ok(Expression::Atom(Atom::String(String::from("Hello!").into())))
     );
     assert_eq!(
         str_().parse("\"Hello!\""),
-        Ok(Expr::Atom(Atom::String(String::from("Hello!").into())))
+        Ok(Expression::Atom(Atom::String(String::from("Hello!").into())))
     );
     assert_eq!(
         str_().parse("'\n'"),
-        Ok(Expr::Atom(Atom::String(String::from("\n").into())))
+        Ok(Expression::Atom(Atom::String(String::from("\n").into())))
     );
     assert_eq!(
         str_().parse(r"'\n'"),
-        Ok(Expr::Atom(Atom::String(String::from("\n").into())))
+        Ok(Expression::Atom(Atom::String(String::from("\n").into())))
     );
 
     assert_eq!(
         str_().parse(r"'''hello'''"),
-        Ok(Expr::Atom(Atom::String(String::from("hello").into())))
+        Ok(Expression::Atom(Atom::String(String::from("hello").into())))
     );
     // Check triple quoted strings interpret escape sequences (note this is a rust raw string, not a CEL raw string)
     assert_eq!(
         str_().parse(r"'''\n'''"),
-        Ok(Expr::Atom(Atom::String(String::from("\n").into())))
+        Ok(Expression::Atom(Atom::String(String::from("\n").into())))
     );
 }
 
@@ -278,43 +278,43 @@ fn test_str_parser() {
 fn test_raw_str_parser() {
     assert_eq!(
         str_().parse(r"r'\n'"),
-        Ok(Expr::Atom(Atom::String(String::from("\\n").into())))
+        Ok(Expression::Atom(Atom::String(String::from("\\n").into())))
     );
     assert_eq!(
         str_().parse(r"R'\n'"),
-        Ok(Expr::Atom(Atom::String(String::from("\\n").into())))
+        Ok(Expression::Atom(Atom::String(String::from("\\n").into())))
     );
     assert_eq!(
         str_().parse("r'1'"),
-        Ok(Expr::Atom(Atom::String(String::from("1").into())))
+        Ok(Expression::Atom(Atom::String(String::from("1").into())))
     );
     assert_eq!(
         str_().parse("r\"Hello!\""),
-        Ok(Expr::Atom(Atom::String(String::from("Hello!").into())))
+        Ok(Expression::Atom(Atom::String(String::from("Hello!").into())))
     );
     assert_eq!(
         str_().parse("R\"Hello!\""),
-        Ok(Expr::Atom(Atom::String(String::from("Hello!").into())))
+        Ok(Expression::Atom(Atom::String(String::from("Hello!").into())))
     );
     assert_eq!(
         str_().parse(r"r'''hello'''"),
-        Ok(Expr::Atom(Atom::String(String::from("hello").into())))
+        Ok(Expression::Atom(Atom::String(String::from("hello").into())))
     );
     assert_eq!(
         str_().parse(r"r'''\n'''"),
-        Ok(Expr::Atom(Atom::String(String::from("\\n").into())))
+        Ok(Expression::Atom(Atom::String(String::from("\\n").into())))
     );
 }
 
-pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
+pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
     let ident = text::ident::<char, Simple<char>>()
         .padded()
-        .map(Expr::Var)
+        .map(Expression::Var)
         .labelled("identifier");
 
     let null = just("null")
         .padded()
-        .map(|_| Expr::Atom(Atom::Null))
+        .map(|_| Expression::Atom(Atom::Null))
         .labelled("null");
 
     let expr = recursive(|expr| {
@@ -332,7 +332,7 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
             .then_ignore(just('('))
             .then(expr_list.clone())
             .then_ignore(just(')'))
-            .map(|(name, args)| Expr::Member(Box::new(name), MemberOp::Call(args)))
+            .map(|(name, args)| Expression::Member(Box::new(name), MemberOp::Call(args)))
             .padded()
             .labelled("function call");
 
@@ -344,7 +344,7 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
             .clone()
             .then(just('.').ignore_then(member.clone()).repeated().at_least(1))
             .foldl(|lhs, rhs| match rhs {
-                Expr::Var(v) => Expr::Member(Box::new(lhs), MemberOp::Attribute(v)),
+                Expression::Var(v) => Expression::Member(Box::new(lhs), MemberOp::Attribute(v)),
                 _ => panic!("Expected identifier after '.'"),
             })
             .labelled("attribute");
@@ -365,14 +365,14 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
 
         let index_access = ident
             .then(index.repeated().at_least(1))
-            .foldl(|lhs, rhs| Expr::Member(Box::new(lhs), MemberOp::Index(rhs)))
+            .foldl(|lhs, rhs| Expression::Member(Box::new(lhs), MemberOp::Index(rhs)))
             .labelled("index access");
 
         let list = expr_list
             .clone()
             // Ignore trailing comma
             .delimited_by(just('['), just(']'))
-            .map(|items| Expr::List(items))
+            .map(|items| Expression::List(items))
             .labelled("list");
 
         let map_item = expr
@@ -387,7 +387,7 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
             .separated_by(just(','))
             .delimited_by(just('{'), just('}'))
             .padded()
-            .map(|items| Expr::Map(items))
+            .map(|items| Expression::Map(items))
             .labelled("map");
 
         let primary = function_call
@@ -409,11 +409,11 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
 
         let not = op('!')
             .ignore_then(primary.clone())
-            .map(|rhs| Expr::Unary(UnaryOp::Not, Box::new(rhs)));
+            .map(|rhs| Expression::Unary(UnaryOp::Not, Box::new(rhs)));
 
         let negation = op('-')
             .ignore_then(primary.clone())
-            .map(|rhs| Expr::Unary(UnaryOp::Neg, Box::new(rhs)))
+            .map(|rhs| Expression::Unary(UnaryOp::Neg, Box::new(rhs)))
             .labelled("negation");
 
         let unary = choice((not, negation))
@@ -427,7 +427,7 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
         let multiplication = unary
             .clone()
             .then(product_div_op.then(unary.clone()).repeated())
-            .foldl(|lhs, (binary_op, rhs)| Expr::Binary(Box::new(lhs), binary_op, Box::new(rhs)))
+            .foldl(|lhs, (binary_op, rhs)| Expression::Binary(Box::new(lhs), binary_op, Box::new(rhs)))
             .labelled("product_or_division")
             .boxed();
 
@@ -436,7 +436,7 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
         let addition = multiplication
             .clone()
             .then(sum_sub_op.then(multiplication.clone()).repeated())
-            .foldl(|lhs, (op, rhs)| Expr::Binary(Box::new(lhs), op, Box::new(rhs)))
+            .foldl(|lhs, (op, rhs)| Expression::Binary(Box::new(lhs), op, Box::new(rhs)))
             .labelled("sub_or_sub")
             .boxed();
 
@@ -451,7 +451,7 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
         let relation = addition
             .clone()
             .then(relationship_op.then(addition.clone()).repeated())
-            .foldl(|lhs, (op, rhs)| Expr::Binary(Box::new(lhs), op, Box::new(rhs)))
+            .foldl(|lhs, (op, rhs)| Expression::Binary(Box::new(lhs), op, Box::new(rhs)))
             .labelled("comparison")
             .boxed();
 
@@ -463,20 +463,20 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
 
 #[test]
 fn test_parser_bool() {
-    assert_eq!(parser().parse("true"), Ok(Expr::Atom(Atom::Bool(true))));
-    assert_eq!(parser().parse("false"), Ok(Expr::Atom(Atom::Bool(false))));
+    assert_eq!(parser().parse("true"), Ok(Expression::Atom(Atom::Bool(true))));
+    assert_eq!(parser().parse("false"), Ok(Expression::Atom(Atom::Bool(false))));
     assert_eq!(
         parser().parse("!false"),
-        Ok(Expr::Unary(
+        Ok(Expression::Unary(
             UnaryOp::Not,
-            Box::new(Expr::Atom(Atom::Bool(false)))
+            Box::new(Expression::Atom(Atom::Bool(false)))
         ))
     );
     assert_eq!(
         parser().parse("!true"),
-        Ok(Expr::Unary(
+        Ok(Expression::Unary(
             UnaryOp::Not,
-            Box::new(Expr::Atom(Atom::Bool(true)))
+            Box::new(Expression::Atom(Atom::Bool(true)))
         ))
     );
 }
@@ -485,10 +485,10 @@ fn test_parser_bool() {
 fn test_parser_binary_bool_expressions() {
     assert_eq!(
         parser().parse("true == true"),
-        Ok(Expr::Binary(
-            Box::new(Expr::Atom(Atom::Bool(true))),
+        Ok(Expression::Binary(
+            Box::new(Expression::Atom(Atom::Bool(true))),
             BinaryOp::Equals,
-            Box::new(Expr::Atom(Atom::Bool(true)))
+            Box::new(Expression::Atom(Atom::Bool(true)))
         ))
     );
 }
@@ -497,20 +497,20 @@ fn test_parser_binary_bool_expressions() {
 fn test_parser_str() {
     assert_eq!(
         parser().parse("'hi'"),
-        Ok(Expr::Atom(Atom::String(String::from("hi").into())))
+        Ok(Expression::Atom(Atom::String(String::from("hi").into())))
     );
     assert_eq!(
         parser().parse("'true'"),
-        Ok(Expr::Atom(Atom::String(String::from("true").into())))
+        Ok(Expression::Atom(Atom::String(String::from("true").into())))
     );
 
     assert_eq!(
         parser().parse("'''true\n'''"),
-        Ok(Expr::Atom(Atom::String(String::from("true\n").into())))
+        Ok(Expression::Atom(Atom::String(String::from("true\n").into())))
     );
     assert_eq!(
         parser().parse(r##""""He said "Hi I'm Brian".""""##),
-        Ok(Expr::Atom(Atom::String(
+        Ok(Expression::Atom(Atom::String(
             String::from("He said \"Hi I'm Brian\".").into()
         )))
     );
@@ -520,52 +520,52 @@ fn test_parser_str() {
 fn test_parser_raw_strings() {
     assert_eq!(
         parser().parse("r'\n'"),
-        Ok(Expr::Atom(Atom::String(String::from("\n").into())))
+        Ok(Expression::Atom(Atom::String(String::from("\n").into())))
     );
 }
 
 #[test]
 fn test_parser_positive_numbers() {
-    assert_eq!(parser().parse("1"), Ok(Expr::Atom(Atom::Int(1))));
-    assert_eq!(parser().parse("1u"), Ok(Expr::Atom(Atom::UInt(1))));
-    assert_eq!(parser().parse("1.0"), Ok(Expr::Atom(Atom::Double(1.0))));
+    assert_eq!(parser().parse("1"), Ok(Expression::Atom(Atom::Int(1))));
+    assert_eq!(parser().parse("1u"), Ok(Expression::Atom(Atom::UInt(1))));
+    assert_eq!(parser().parse("1.0"), Ok(Expression::Atom(Atom::Double(1.0))));
 }
 
 #[test]
 fn test_parser_negative_numbers() {
     assert_eq!(
         parser().parse("-1"),
-        Ok(Expr::Unary(
+        Ok(Expression::Unary(
             UnaryOp::Neg,
-            Box::new(Expr::Atom(Atom::Int(1)))
+            Box::new(Expression::Atom(Atom::Int(1)))
         ))
     );
     assert_eq!(
         parser().parse("-1u"),
-        Ok(Expr::Unary(
+        Ok(Expression::Unary(
             UnaryOp::Neg,
-            Box::new(Expr::Atom(Atom::UInt(1)))
+            Box::new(Expression::Atom(Atom::UInt(1)))
         ))
     );
     assert_eq!(
         parser().parse("-1e3"),
-        Ok(Expr::Unary(
+        Ok(Expression::Unary(
             UnaryOp::Neg,
-            Box::new(Expr::Atom(Atom::Double(1000.0)))
+            Box::new(Expression::Atom(Atom::Double(1000.0)))
         ))
     );
     assert_eq!(
         parser().parse("-1e-3"),
-        Ok(Expr::Unary(
+        Ok(Expression::Unary(
             UnaryOp::Neg,
-            Box::new(Expr::Atom(Atom::Double(0.001)))
+            Box::new(Expression::Atom(Atom::Double(0.001)))
         ))
     );
     assert_eq!(
         parser().parse("-1.4e-3"),
-        Ok(Expr::Unary(
+        Ok(Expression::Unary(
             UnaryOp::Neg,
-            Box::new(Expr::Atom(Atom::Double(0.0014)))
+            Box::new(Expression::Atom(Atom::Double(0.0014)))
         ))
     );
 }
@@ -574,9 +574,9 @@ fn test_parser_negative_numbers() {
 fn test_parser_delimited_expressions() {
     assert_eq!(
         parser().parse("(-((1)))"),
-        Ok(Expr::Unary(
+        Ok(Expression::Unary(
             UnaryOp::Neg,
-            Box::new(Expr::Atom(Atom::Int(1)))
+            Box::new(Expression::Atom(Atom::Int(1)))
         ))
     );
 }
@@ -585,32 +585,32 @@ fn test_parser_delimited_expressions() {
 fn test_parser_binary_product_expressions() {
     assert_eq!(
         parser().parse("2 * 3"),
-        Ok(Expr::Binary(
-            Box::new(Expr::Atom(Atom::Int(2))),
+        Ok(Expression::Binary(
+            Box::new(Expression::Atom(Atom::Int(2))),
             BinaryOp::Mul,
-            Box::new(Expr::Atom(Atom::Int(3)))
+            Box::new(Expression::Atom(Atom::Int(3)))
         ))
     );
     assert_eq!(
         parser().parse("2 * -3"),
-        Ok(Expr::Binary(
-            Box::new(Expr::Atom(Atom::Int(2))),
+        Ok(Expression::Binary(
+            Box::new(Expression::Atom(Atom::Int(2))),
             BinaryOp::Mul,
-            Box::new(Expr::Unary(
+            Box::new(Expression::Unary(
                 UnaryOp::Neg,
-                Box::new(Expr::Atom(Atom::Int(3)))
+                Box::new(Expression::Atom(Atom::Int(3)))
             ))
         ))
     );
 
     assert_eq!(
         parser().parse("2 / -3"),
-        Ok(Expr::Binary(
-            Box::new(Expr::Atom(Atom::Int(2))),
+        Ok(Expression::Binary(
+            Box::new(Expression::Atom(Atom::Int(2))),
             BinaryOp::Div,
-            Box::new(Expr::Unary(
+            Box::new(Expression::Unary(
                 UnaryOp::Neg,
-                Box::new(Expr::Atom(Atom::Int(3)))
+                Box::new(Expression::Atom(Atom::Int(3)))
             ))
         ))
     );
@@ -620,20 +620,20 @@ fn test_parser_binary_product_expressions() {
 fn test_parser_sum_expressions() {
     assert_eq!(
         parser().parse("2 + 3"),
-        Ok(Expr::Binary(
-            Box::new(Expr::Atom(Atom::Int(2))),
+        Ok(Expression::Binary(
+            Box::new(Expression::Atom(Atom::Int(2))),
             BinaryOp::Add,
-            Box::new(Expr::Atom(Atom::Int(3)))
+            Box::new(Expression::Atom(Atom::Int(3)))
         ))
     );
     assert_eq!(
         parser().parse("2 - -3"),
-        Ok(Expr::Binary(
-            Box::new(Expr::Atom(Atom::Int(2))),
+        Ok(Expression::Binary(
+            Box::new(Expression::Atom(Atom::Int(2))),
             BinaryOp::Sub,
-            Box::new(Expr::Unary(
+            Box::new(Expression::Unary(
                 UnaryOp::Neg,
-                Box::new(Expr::Atom(Atom::Int(3)))
+                Box::new(Expression::Atom(Atom::Int(3)))
             ))
         ))
     );

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -358,17 +358,13 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
             .ignore_then(expr_list.clone())
             .then_ignore(just(')'))
             .map(|args: Vec<Expression>| Member::FunctionCall(args))
-            .labelled("primary function call");
+            .labelled("function call");
 
-        // TODO this moves to member
-        // let index = expr_list
-        //     .clone()
-        //     .delimited_by(just('['), just(']'))
-        //     .labelled("index");
-        // let index_access = ident
-        //     .then(index.repeated().at_least(1))
-        //     .foldl(|lhs, rhs| Expression::Member(Box::new(lhs), Member::Index(rhs)))
-        //     .labelled("index access");
+        let index_access = just('[')
+            .ignore_then(expr.clone())
+            .then_ignore(just(']'))
+            .map(|arg: Expression| Member::Index(Box::new(arg)))
+            .labelled("index");
 
         let list = expr_list
             .clone()
@@ -410,7 +406,7 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
                     choice((
                         attribute_access.clone(),
                         function_call.clone(),
-                        // index access
+                        index_access.clone(),
                     ))
                     .repeated(),
                 )

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Atom, BinaryOp, Expression, MemberOp, UnaryOp};
+use crate::ast::{Atom, ArithmeticOp, Expression, MemberOp, UnaryOp};
 
 use chumsky::prelude::*;
 use chumsky::Parser;
@@ -422,7 +422,7 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
             .boxed()
             .labelled("unary");
 
-        let product_div_op = op('*').to(BinaryOp::Mul).or(op('/').to(BinaryOp::Div));
+        let product_div_op = op('*').to(ArithmeticOp::Multiply).or(op('/').to(ArithmeticOp::Divide));
 
         let multiplication = unary
             .clone()
@@ -431,7 +431,7 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
             .labelled("product_or_division")
             .boxed();
 
-        let sum_sub_op = op('+').to(BinaryOp::Add).or(op('-').to(BinaryOp::Sub));
+        let sum_sub_op = op('+').to(ArithmeticOp::Add).or(op('-').to(ArithmeticOp::Subtract));
 
         let addition = multiplication
             .clone()
@@ -441,12 +441,12 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
             .boxed();
 
         let relationship_op = just("==")
-            .to(BinaryOp::Equals)
-            .or(just("!=").to(BinaryOp::NotEquals))
-            .or(just(">=").to(BinaryOp::GreaterThanOrEqual))
-            .or(just("<=").to(BinaryOp::LessThanOrEqual))
-            .or(just('>').to(BinaryOp::GreaterThan))
-            .or(just('<').to(BinaryOp::LessThan));
+            .to(ArithmeticOp::Equals)
+            .or(just("!=").to(ArithmeticOp::NotEquals))
+            .or(just(">=").to(ArithmeticOp::GreaterThanOrEqual))
+            .or(just("<=").to(ArithmeticOp::LessThanOrEqual))
+            .or(just('>').to(ArithmeticOp::GreaterThan))
+            .or(just('<').to(ArithmeticOp::LessThan));
 
         let relation = addition
             .clone()
@@ -487,7 +487,7 @@ fn test_parser_binary_bool_expressions() {
         parser().parse("true == true"),
         Ok(Expression::Binary(
             Box::new(Expression::Atom(Atom::Bool(true))),
-            BinaryOp::Equals,
+            ArithmeticOp::Equals,
             Box::new(Expression::Atom(Atom::Bool(true)))
         ))
     );
@@ -587,7 +587,7 @@ fn test_parser_binary_product_expressions() {
         parser().parse("2 * 3"),
         Ok(Expression::Binary(
             Box::new(Expression::Atom(Atom::Int(2))),
-            BinaryOp::Mul,
+            ArithmeticOp::Multiply,
             Box::new(Expression::Atom(Atom::Int(3)))
         ))
     );
@@ -595,7 +595,7 @@ fn test_parser_binary_product_expressions() {
         parser().parse("2 * -3"),
         Ok(Expression::Binary(
             Box::new(Expression::Atom(Atom::Int(2))),
-            BinaryOp::Mul,
+            ArithmeticOp::Multiply,
             Box::new(Expression::Unary(
                 UnaryOp::Neg,
                 Box::new(Expression::Atom(Atom::Int(3)))
@@ -607,7 +607,7 @@ fn test_parser_binary_product_expressions() {
         parser().parse("2 / -3"),
         Ok(Expression::Binary(
             Box::new(Expression::Atom(Atom::Int(2))),
-            BinaryOp::Div,
+            ArithmeticOp::Divide,
             Box::new(Expression::Unary(
                 UnaryOp::Neg,
                 Box::new(Expression::Atom(Atom::Int(3)))
@@ -622,7 +622,7 @@ fn test_parser_sum_expressions() {
         parser().parse("2 + 3"),
         Ok(Expression::Binary(
             Box::new(Expression::Atom(Atom::Int(2))),
-            BinaryOp::Add,
+            ArithmeticOp::Add,
             Box::new(Expression::Atom(Atom::Int(3)))
         ))
     );
@@ -630,7 +630,7 @@ fn test_parser_sum_expressions() {
         parser().parse("2 - -3"),
         Ok(Expression::Binary(
             Box::new(Expression::Atom(Atom::Int(2))),
-            BinaryOp::Sub,
+            ArithmeticOp::Subtract,
             Box::new(Expression::Unary(
                 UnaryOp::Neg,
                 Box::new(Expression::Atom(Atom::Int(3)))

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -237,27 +237,24 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
         .labelled("primary")
         .boxed();
 
-        let member = recursive(|member| {
-            let member_chain = primary
-                .clone()
-                .then(
-                    choice((
-                        attribute_access.clone(),
-                        function_call.clone(),
-                        index_access.clone(),
-                    ))
-                    .repeated(),
-                )
-                .map(|(lhs_expression, members)| {
-                    members.into_iter().fold(lhs_expression, |acc, member| {
-                        Expression::Member(Box::new(acc), member)
-                    })
+        let member_chain = primary
+            .clone()
+            .then(
+                choice((
+                    attribute_access.clone(),
+                    function_call.clone(),
+                    index_access.clone(),
+                ))
+                .repeated(),
+            )
+            .map(|(lhs_expression, members)| {
+                members.into_iter().fold(lhs_expression, |acc, member| {
+                    Expression::Member(Box::new(acc), member)
                 })
-                .labelled("member");
+            })
+            .labelled("member");
 
-            choice((member_chain, primary.clone()))
-        })
-        .boxed();
+        let member = choice((member_chain, primary.clone()));
 
         let op = |c| just::<char, _, Simple<char>>(c).padded();
 


### PR DESCRIPTION
This branch switches to the AST from https://github.com/clarkmcc/cel-rust and finishes off the bulk of the parser adding:
 
- `&&` and `||` conditionals
- ternary operator
- more parser and interpreter tests

The only missing part of the parser is `FieldInits` as part of `primary`. 