### PR TITLE
Feature/field inits

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -45,6 +45,7 @@ pub enum Member {
     Attribute(String),
     FunctionCall(Vec<Expression>),
     Index(Box<Expression>),
+    Fields(Vec<(Rc<String>, Expression)>),
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -501,4 +501,27 @@ mod tests {
             ),
         );
     }
+
+    #[test]
+    fn test_nested_field_init() {
+        assert_parse_eq(
+            "common.GeoPoint{ latitude: 10.0, longitude: 5.5 }",
+            Expression::Member(
+                Box::new(Expression::Member(
+                    Box::new(Expression::Ident(String::from("common").into())),
+                    Member::Attribute(String::from("GeoPoint")),
+                )),
+                Member::Fields(vec![
+                    (
+                        String::from("latitude").into(),
+                        Expression::Atom(Atom::Float(10.0)),
+                    ),
+                    (
+                        String::from("longitude").into(),
+                        Expression::Atom(Atom::Float(5.5)),
+                    ),
+                ]),
+            ),
+        );
+    }
 }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ast;
 pub mod parser;
+
 use chumsky::error::Simple;
 use chumsky::Parser;
 
@@ -477,6 +478,26 @@ mod tests {
                     ),
                 ])),
                 Member::Index(Box::new(Expression::Atom(Atom::Int(0)))),
+            ),
+        );
+    }
+
+    #[test]
+    fn test_field_init() {
+        assert_parse_eq(
+            "GeoPoint{ latitude: 10.0, longitude: 5.5 }",
+            Expression::Member(
+                Box::new(Expression::Ident(String::from("GeoPoint").into())),
+                Member::Fields(vec![
+                    (
+                        String::from("latitude").into(),
+                        Expression::Atom(Atom::Float(10.0)),
+                    ),
+                    (
+                        String::from("longitude").into(),
+                        Expression::Atom(Atom::Float(5.5)),
+                    ),
+                ]),
             ),
         );
     }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -300,9 +300,7 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
         let field_item = field_identifier
             .clone()
             .then_ignore(just(':'))
-            .then(expr.clone())
-            //.map(|(name, value)| (name, value))
-            ;
+            .then(expr.clone());
 
         let field_items = field_item
             .clone()
@@ -311,13 +309,10 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
             .padded()
             .labelled("field items");
 
-        // TODO Need to handle nested identifiers here
         let field_inits = ident
             .clone()
             .then(just('.').ignore_then(ident.clone()).repeated())
             .foldl(|lhs: Expression, rhs: Expression| {
-                // Processing a list of Ident expressions
-                // foldl starts with the first element (Ident Expression) and works to the right
                 // We convert the Ident Expressions to attribute member expressions except for the left most one
                 // Ident(A), Ident(B) -> Member(Ident(A), Attribute(B))
                 // Member(Ident(A), Attribute(B)), Ident(C) -> Member(Member(Ident(A), Attribute(B)), Attribute(C))

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -311,10 +311,13 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
             .labelled("field items");
 
         // TODO Need to handle nested identifiers here
-        // e.g. `.then(just('.').then(ident.clone())).repeated()`
-
         let field_inits = ident
             .clone()
+            // .then(just('.').then(ident.clone()))
+            // .repeated()
+            // .foldr(|lhs_ident_expression: Expression, rhs: Expression| {
+            //     Expression::Member(lhs_ident_expression, Member::Attribute())
+            // })
             .then(field_items)
             .map(|(name, items)| Expression::Member(Box::new(name), Member::Fields(items)));
 

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -313,23 +313,14 @@ pub fn parser() -> impl Parser<char, Expression, Error = Simple<char>> {
         // TODO Need to handle nested identifiers here
         // e.g. `.then(just('.').then(ident.clone())).repeated()`
 
-        // let field_inits = ident
-        //     .clone()
-        //     .then(field_items)
-        //     .map(|(name, items)| {
-        //         Expression::Member(name, Member::Fields(items))
-        //     })
+        let field_inits = ident
+            .clone()
+            .then(field_items)
+            .map(|(name, items)| Expression::Member(Box::new(name), Member::Fields(items)));
 
-        let primary = choice((
-            literal,
-            ident,
-            expr_in_paren,
-            list,
-            map,
-            // TODO field inits here
-        ))
-        .labelled("primary")
-        .boxed();
+        let primary = choice((literal, field_inits, ident, expr_in_paren, list, map))
+            .labelled("primary")
+            .boxed();
 
         let member_chain = primary
             .clone()


### PR DESCRIPTION
Parses FieldInit expressions e.g. `Account{user_id: 'Pokemon'}`. 

Nested identifiers (such as `a.b.c{f: []}`) are supported and will be parsed into the following AST: `Member(Member(Member(Ident("a"), Attribute("b")), Attribute("c")), Fields([("f", List([]))]))`.

Or visually:

![image](https://github.com/hardbyte/common-expression-language/assets/855189/8470e296-847b-4c21-9e60-ae9a7d9d3b41)
