### PR TITLE
Add benchmarks and CI workflow for running them

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,25 @@
+name: Benchmark
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run benchmarks
+        run: cargo bench
+      - uses: actions/upload-artifact@v3
+        with:
+          name: benchmark-results
+          path: target/criterion/report/


### PR DESCRIPTION
Related to #11

This pull request introduces benchmarking capabilities to the GitHub Actions workflow and extends the existing benchmark suite for the CEL parser.

- **Adds a new GitHub Actions workflow** `.github/workflows/benchmark.yml` to run benchmarks on push events to the `main` branch and on pull requests. This workflow sets up the Rust environment, runs `cargo bench` to execute all benchmarks, and uploads the benchmark results as artifacts.
- **Expands the benchmark suite** in `parser/benches/cel_parsing_benchmark.rs` by adding benchmarks for evaluating expressions using the `cel_interpreter::eval` function. It includes benchmarks for different types of expressions such as simple arithmetic, logical expressions, function calls, and error scenarios. It also adds a benchmark for a realistic CEL expression that might be encountered in real-world usage, ensuring a comprehensive evaluation of the parser's performance.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hardbyte/common-expression-language/issues/11?shareId=fb9a9526-4a60-40e6-940a-3a3f9e5db0f3).